### PR TITLE
Revert "Implement local file image loading"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text

--- a/NadekoBot.Core/Services/Common/ImageLoader.cs
+++ b/NadekoBot.Core/Services/Common/ImageLoader.cs
@@ -36,14 +36,7 @@ namespace NadekoBot.Core.Services.Common
             {
                 try
                 {
-                    // Resolve the path relative to the data directory. file://
-                    // URIs don't actually support relative paths, so LocalPath
-                    // comes out as an absolute path. To fix this, we cheekily
-                    // append a ./ so that it turns into a relative path.
-                    String relativePath = "./" + uri.LocalPath;
-                    String basePath = Path.Combine(Environment.CurrentDirectory, "data");
-                    String imagePath = Path.GetFullPath(relativePath, basePath);
-                    var bytes = await File.ReadAllBytesAsync(imagePath);
+                    var bytes = await File.ReadAllBytesAsync(uri.LocalPath);
                     return bytes;
                 }
                 catch (Exception ex)

--- a/src/NadekoBot/data/images.json
+++ b/src/NadekoBot/data/images.json
@@ -31,7 +31,7 @@
     "Dot": "https://nadeko-pictures.nyc3.digitaloceanspaces.com/other/rategirl/dot.png"
   },
   "Xp": {
-    "Bg": "file:///images/xp_bg.png"
+    "Bg": "https://i.imgur.com/apT9Uvo.png"
   },
   "Rip": {
     "Bg": "https://nadeko-pictures.nyc3.digitaloceanspaces.com/other/rip/rip.png",
@@ -58,6 +58,6 @@
       "https://nadeko-pictures.nyc3.digitaloceanspaces.com/other/slots/numbers/8.png",
       "https://nadeko-pictures.nyc3.digitaloceanspaces.com/other/slots/numbers/9.png"
     ],
-    "Bg": "file:///images/slots_bg.png"
+    "Bg": "https://i.imgur.com/CkN2LCa.png"
   }
 }

--- a/src/NadekoBot/data/images/slots_bg.png
+++ b/src/NadekoBot/data/images/slots_bg.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b3c2d66440ca9193513804f0fd543344a601e3477288509844cb41c414a0999
-size 198560

--- a/src/NadekoBot/data/images/xp_bg.png
+++ b/src/NadekoBot/data/images/xp_bg.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db8f407309644edb61ed5833238ea3a260f02766f818414f7688d31dc57178b7
-size 239617


### PR DESCRIPTION
This reverts commit 458ba7f332c8e6dd355192e478196c5111eb552e.

It doesn't acutally work; after some time a task tries to refresh the
images and the next time they get loaded an exception gets thrown.